### PR TITLE
Add a with-test build job to the opam package definition

### DIFF
--- a/lambdasoup.opam
+++ b/lambdasoup.opam
@@ -28,6 +28,7 @@ pin-depends: [
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"] {with-test}
 ]
 
 description: """

--- a/lambdasoup.opam
+++ b/lambdasoup.opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
 
   "bisect_ppx" {dev & >= "2.0.0"}
-  "ounit" {dev}
+  "ounit" {with-test}
 ]
 
 pin-depends: [


### PR DESCRIPTION
This entry is relied upon by `opam` when installing packages using
`--with-test`, such as when being tested by OCaml-CI.