### PR TITLE
Use a dedicated exception for selector parse errors.

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -1,7 +1,7 @@
 (* This file is part of Lambda Soup, released under the MIT license. See
    LICENSE.md for details, or visit https://github.com/aantron/lambdasoup. *)
 
-exception Selector_parse_error of string
+exception Parse_error of string
 
 module String =
 struct
@@ -661,7 +661,7 @@ struct
     | 'F' | 'f' -> 0xF
     | c -> Char.code c - Char.code '0'
 
-  let parse_error msg = raise (Selector_parse_error msg)
+  let parse_error msg = raise (Parse_error msg)
 
   let rec parse_hexadecimal_escape value count stream =
     if count >= 6 then

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -70,7 +70,7 @@ let _ = ul |> previous_siblings |> elements in
 (** {2 Exceptions} *)
 
 (** Raised when a CSS selector given to {!select} and similar functions is syntactically invalid. *)
-exception Selector_parse_error of string
+exception Parse_error of string
 
 (** {2 Types} *)
 

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -67,7 +67,10 @@ let _ = ul |> previous_siblings |> elements in
     for other versions can be downloaded from the
     {{:https://github.com/aantron/lambdasoup/releases} releases page}. *)
 
+(** {2 Exceptions} *)
 
+(** Raised when a CSS selector given to {!select} and similar functions is syntactically invalid. *)
+exception Selector_parse_error of string
 
 (** {2 Types} *)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -159,7 +159,7 @@ let suites = [
         (try
           soup |> select selector |> ignore; false
         with
-        | Soup.Selector_parse_error _ -> true
+        | Soup.Parse_error _ -> true
         | _ -> false) |> assert_bool "expected Failure"
       in
 
@@ -214,7 +214,7 @@ let suites = [
           with
           | Failure s ->
             assert_failure (Printf.sprintf "%s: got \"%s\"" selector s)
-          | Soup.Selector_parse_error message ->
+          | Soup.Parse_error message ->
             if (message <> expected_message) then assert_failure
               (Printf.sprintf "Incorrect parse error for selector '%s': expected '%s' but got '%s'"
                  selector expected_message message)


### PR DESCRIPTION
Right now, `Soup.Selector.parse` fails with a generic `Failure` if it cannot parse a selector. This requires a rather inelegant test that looks inside the message, and also makes it hard for clients to give the user a meaningful error message for a bad selector.

A separate exception (which I named `Soup.Selector_parse_error`) makes for a cleaner test suite and simpler error reporting.

It's also a compatibility concern. I glanced through packages that depend on lambdasoup (mechaml, socialpeek...) and it looks like none of them accept selector strings from the user, or rely on the current behaviour.
Soupault seems to be the only lambdasoup client that allows user-defined selectors, and that's the reason I'm making the PR, but I believe web scraping libraries and similar can benefit from it if as well, if they decide to add flexibility and support custom selectors.