### PR TITLE
Make forced HTML5 doctype optional.

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -970,7 +970,7 @@ struct
   let ($$) = ($$)
 end
 
-let signals root =
+let signals ?(force_html5=false) root =
   let root = forget_type root in
 
   let rec traverse acc = function
@@ -990,6 +990,7 @@ let signals root =
   in
 
   let signals = List.rev (traverse [] root) |> Markup.of_list in
+  if not force_html5 then signals else
   match root with
   | {values =
     `Document {roots = {values = `Element {name = "html"; _}; _}::_}; _}
@@ -999,12 +1000,12 @@ let signals root =
   | _ ->
     signals
 
-let pretty_print root =
-  signals root
+let pretty_print ?(force_html5=false) root =
+  signals ~force_html5:force_html5 root
   |> Markup.pretty_print |> (fun s -> Markup.write_html s) |> Markup.to_string
 
-let to_string root =
-  signals root |> (fun s -> Markup.write_html s) |> Markup.to_string
+let to_string ?(force_html5=false) root =
+  signals ~force_html5:force_html5 root |> (fun s -> Markup.write_html s) |> Markup.to_string
 
 let rec equal_general normalize_children n n' =
   let equal_text s s' = s = s' in

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -462,11 +462,11 @@ val at_most_one_child : (_ node) -> bool
 
 (** {2 Printing} *)
 
-val to_string : (_ node) -> string
+val to_string : ?force_html5:bool -> (_ node) -> string
 (** Converts the node tree rooted at the given node to an HTML5 string,
     preserving whitespace nodes. *)
 
-val pretty_print : (_ node) -> string
+val pretty_print : ?force_html5:bool -> (_ node) -> string
 (** Converts the node tree rooted at the given node to an HTML5 string formatted
     for easy reading by humans, difference algorthims, etc.
 
@@ -494,7 +494,7 @@ val pretty_print : (_ node) -> string
     overview} may be a good place to start.
  *)
 
-val signals : (_ node) -> (Markup.signal, Markup.sync) Markup.stream
+val signals : ?force_html5:bool  -> (_ node) -> (Markup.signal, Markup.sync) Markup.stream
 (** Converts the node tree rooted at the given node to a stream of Markup.ml
     signals. This underlies {!to_string} and {!pretty_print}.
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1033,10 +1033,10 @@ let suites = [
          "<body class=\"testing\">\n<p>foo</p>\n<p>bar</p>\n</body></html>")
       in
 
-      assert_equal document (document |> parse |> to_string);
+      assert_equal document (document |> parse |> to_string ~force_html5:true);
       assert_bool "pretty_print"
         (equal_modulo_whitespace
-          (parse document) (parse document |> pretty_print |> parse)));
+          (parse document) (parse document |> pretty_print ~force_html5:true|> parse)));
 
     ("entity" >:: fun _ ->
       assert_equal ("<p>&amp;</p>" |> parse |> R.leaf_text) "&");
@@ -1049,11 +1049,11 @@ let suites = [
 
     ("doctype" >:: fun _ ->
       assert_equal
-        ("<html></html>" |> parse |> to_string)
+        ("<html></html>" |> parse |> to_string ~force_html5:true)
         "<!DOCTYPE html><html><head></head><body></body></html>";
 
       assert_equal
-        ("<html></html>" |> parse $ "html" |> to_string)
+        ("<html></html>" |> parse $ "html" |> to_string ~force_html5:true)
         "<!DOCTYPE html><html><head></head><body></body></html>");
 
     ("R.select_one" >:: fun _ ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -1038,6 +1038,17 @@ let suites = [
         (equal_modulo_whitespace
           (parse document) (parse document |> pretty_print ~force_html5:true|> parse)));
 
+    ("pretty_print_no_doctype" >:: fun _ ->
+      let document =
+        ("<html><head></head>" ^
+         "<body class=\"testing\">\n<p>foo</p>\n<p>bar</p>\n</body></html>")
+      in
+
+      assert_equal document (document |> parse |> to_string);
+      assert_bool "pretty_print"
+        (equal_modulo_whitespace
+          (parse document) (parse document |> pretty_print |> parse)));
+
     ("entity" >:: fun _ ->
       assert_equal ("<p>&amp;</p>" |> parse |> R.leaf_text) "&");
 


### PR DESCRIPTION
Backwards-compatible version of the improvement proposed in #32 