### PR TITLE
Use misnested body attributes

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -120,8 +120,7 @@ let parse text =
     match e with
     | `Misnested_tag ("body", _, attributes) ->
       body_attributes := !body_attributes @ attributes
-    | _ -> ()
-  in
+    | _ -> () in
   text
   |> Markup.string
   |> (fun s -> Markup.parse_html ~report s)

--- a/src/soup.ml
+++ b/src/soup.ml
@@ -131,7 +131,7 @@ let parse text =
       match name with
       | ns, "body" when ns = Markup.Ns.html ->
         List.fold_left (fun attributes (n, v) ->
-          match List.map fst attributes |> List.mem n with
+          match List.mem_assoc n attributes with
           | true -> attributes
           | false -> (n, v) :: attributes
         ) attributes !body_attributes

--- a/src/soup.ml
+++ b/src/soup.ml
@@ -97,24 +97,45 @@ let create_document roots =
 
 let create_soup () = create_document []
 
-let from_signals signals =
+let from_signals' ~map_attributes signals =
   signals
   |> (fun s -> Markup.trees
     ~text:(fun ss -> create_text (String.concat "" ss))
     ~element:(fun name attributes children ->
       let attributes =
-        attributes |> List.map (fun ((_, n), v) -> n, v) in
+        attributes
+        |> List.map (fun ((_, n), v) -> n, v)
+        |> map_attributes name in
       create_element (snd name) attributes children)
     s)
   |> Markup.to_list
   |> create_document
 
+let from_signals =
+  from_signals' ~map_attributes:(fun _n a -> a)
+
 let parse text =
+  let body_attributes = ref [] in
+  let report _l e =
+    match e with
+    | `Misnested_tag ("body", _, attributes) ->
+      body_attributes := !body_attributes @ attributes
+    | _ -> ()
+  in
   text
   |> Markup.string
-  |> (fun s -> Markup.parse_html s)
+  |> (fun s -> Markup.parse_html ~report s)
   |> Markup.signals
-  |> from_signals
+  |> from_signals'
+    ~map_attributes:(fun name attributes ->
+      match name with
+      | ns, "body" when ns = Markup.Ns.html ->
+        List.fold_left (fun attributes (n, v) ->
+          match List.map fst attributes |> List.mem n with
+          | true -> attributes
+          | false -> (n, v) :: attributes
+        ) attributes !body_attributes
+      | _ -> attributes)
 
 let is_document node =
   match node.values with

--- a/test/test.ml
+++ b/test/test.ml
@@ -1097,6 +1097,12 @@ let suites = [
       close_in channel;
 
       assert_equal (parse contents $$ "li" |> count) 5);
+
+    ("misnested-body-attributes" >:: fun _ ->
+      let document1 = "<html><body id='a'><img><body class='cls' id='b'>" in
+      let document2 = "<html><body id='a' class='cls'><img>" in
+
+      assert_bool "equal" (equal (parse document1) (parse document2)));
   ]
 ]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1100,9 +1100,11 @@ let suites = [
 
     ("misnested-body-attributes" >:: fun _ ->
       let document1 = "<html><body id='a'><img><body class='cls' id='b'>" in
-      let document2 = "<html><body id='a' class='cls'><img>" in
+      let document2 = "<html><img><body class='cls' id='a'>" in
+      let document3 = "<html><body id='a' class='cls'><img>" in
 
-      assert_bool "equal" (equal (parse document1) (parse document2)));
+      assert_bool "equal" (equal (parse document1) (parse document2));
+      assert_bool "equal" (equal (parse document1) (parse document3)));
   ]
 ]
 


### PR DESCRIPTION
This relates to https://github.com/aantron/markup.ml/issues/54:  attributes on illegally positioned (misnested) body tags are disappeared.  This PR tries to correct that behaviour to follow the spec, where such attributes are moved to the main body tag, if they are not already defined there.

It won't win a beauty contest, but I think it does what is needed.