### PR TITLE
Add `Soup.prepend_root`

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -1195,6 +1195,11 @@ let append_root document node =
   mutate_child_list (fun f -> f @ [forget_type node]) document;
   node.parent <- Some document
 
+let prepend_root document node =
+  delete node;
+  mutate_child_list (fun f -> (forget_type node) :: f) document;
+  node.parent <- Some document
+
 let set_name new_name = function
   | {values = `Element e; _} ->
     e.name <- new_name |> String.trim |> String.lowercase_ascii

--- a/src/soup.ml
+++ b/src/soup.ml
@@ -1197,7 +1197,7 @@ let append_root document node =
 
 let prepend_root document node =
   delete node;
-  mutate_child_list (fun f -> (forget_type node) :: f) document;
+  mutate_child_list (fun f -> (forget_type node)::f) document;
   node.parent <- Some document
 
 let set_name new_name = function

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -633,11 +633,11 @@ val unwrap : (_ node) -> unit
 (** [unwrap node] unlinks [node], and inserts all of [node]'s children as
     children of [node]'s parent at the former location of [node]. *)
 
-val prepend_root : soup node -> (_ node) -> unit
-(** [prepend_root soup node] adds [node] as the first root node of [soup]. *)
-
 val append_root : soup node -> (_ node) -> unit
 (** [append_root soup node] adds [node] as the last root node of [soup]. *)
+
+val prepend_root : soup node -> (_ node) -> unit
+(** [prepend_root soup node] adds [node] as the first root node of [soup]. *)
 
 val set_name : string -> element node -> unit
 (** Sets the tag name of the given element. *)

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -633,6 +633,9 @@ val unwrap : (_ node) -> unit
 (** [unwrap node] unlinks [node], and inserts all of [node]'s children as
     children of [node]'s parent at the former location of [node]. *)
 
+val prepend_root : soup node -> (_ node) -> unit
+(** [prepend_root soup node] adds [node] as the first root node of [soup]. *)
+
 val append_root : soup node -> (_ node) -> unit
 (** [append_root soup node] adds [node] as the last root node of [soup]. *)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -869,6 +869,12 @@ let suites = [
         (element |> texts)
         ["five"; "three"; "four"; "one"; "six"; "two"; "seven"]);
 
+    ("append-prepend-root" >:: fun _ ->
+      let soup = parse "test2" in
+      append_root soup (parse "test3");
+      prepend_root soup (parse "test1");
+      assert_equal (soup |> texts) ["test1"; "test2"; "test3"]);
+
     ("delete" >:: fun _ ->
       let body = page "list" |> parse $ "body" in
       let ul = body $ "ul" in


### PR DESCRIPTION
There's `Soup.append_root` but there's no `Soup.prepend_root`, and without it, inserting something before the very first node in a soup seems impossible.

This patch fixes that and also adds a test for append/prepend root functions specifically.