### PR TITLE
Add Soup.is_document and Soup.is_text to the public API

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -144,6 +144,12 @@ let is_element node =
   | `Text _ -> false
   | `Document _ -> false
 
+let is_text node =
+  match node.values with
+  | `Text _ -> true
+  | `Element _ -> false
+  | `Document _ -> false
+
 let element node =
   if is_element node then Some (forget_type node) else None
 

--- a/src/soup.mli
+++ b/src/soup.mli
@@ -303,6 +303,8 @@ some text                                =>   Some "some text"
 
  *)
 
+val is_text : (_ node) -> bool
+(** Indicates whether the given node is a text node. *)
 
 
 (** {2 Elementary traversals} *)
@@ -432,6 +434,9 @@ val parent : (_ node) -> element node option
 val is_root : (_ node) -> bool
 (** Indicates whether the given node is not a soup node, and either has no
     parent, or its parent is a soup node. *)
+
+val is_document : (_ node) -> bool
+(** Indicates whether the given node is a soup (document) node. *)
 
 val child : (_ node) -> general node option
 (** [child node] evaluates to [node]'s first child. Equivalent to


### PR DESCRIPTION
For code that manipulates element trees, it's handy to be able to check what kind of a node a function is dealing with.

As of 1.0.0, only `Soup.is_element` is exposed in the public API. `Soup.is_document` exists internally but isn't exposed, and `Soup.is_text` doesn't exist at all. All three are trivial to add and expose.

This PR exposes a complete set of node type checks.

If you want me to add tests for those functions, I can do it as well.