### PR TITLE
Don't remove namespaces from attributes

### DIFF
--- a/src/soup.ml
+++ b/src/soup.ml
@@ -100,9 +100,10 @@ let from_signals' ~map_attributes signals =
     ~element:(fun name attributes children ->
       let attributes =
         attributes
-        |> List.map (fun ((ns, n), v) -> match ns with
-            | "" -> (n, v)
-            | _ -> (ns ^ ":" ^ n, v))
+        |> List.map (fun ((ns, n), v) ->
+          match ns with
+          | "" -> (n, v)
+          | _ -> (ns ^ ":" ^ n, v))
         |> map_attributes name in
       create_element (snd name) attributes children)
     s)

--- a/src/soup.ml
+++ b/src/soup.ml
@@ -100,7 +100,9 @@ let from_signals' ~map_attributes signals =
     ~element:(fun name attributes children ->
       let attributes =
         attributes
-        |> List.map (fun ((_, n), v) -> n, v)
+        |> List.map (fun ((ns, n), v) -> match ns with
+            | "" -> (n, v)
+            | _ -> (ns ^ ":" ^ n, v))
         |> map_attributes name in
       create_element (snd name) attributes children)
     s)

--- a/test/pages/list.html
+++ b/test/pages/list.html
@@ -1,5 +1,5 @@
 <html>
-<body class="lists">
+<body class="lists" my:attr="value">
 
 <ul>
   <li id="one" class="odd">Item 1</li>

--- a/test/test.ml
+++ b/test/test.ml
@@ -357,6 +357,7 @@ let suites = [
       in
 
       value "body" "class" (Some "lists");
+      value "body" "my:attr" (Some "value");
       value "li#two" "id" (Some "two");
       value "html" "id" None;
 


### PR DESCRIPTION
A very naive implementation of including the namespace in attribute names.
Could lead to performance and memory problems when a lot of namespaced attributes are present, since this creates a new string for each attribute.
There might be an argument for changing the API of `Markup` instead, but this was the most straightforward fix I could think of.

Fixes #12 